### PR TITLE
Wrong attribute name used for predicates in queries

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -38,7 +38,7 @@ Query.prototype = {
     }
 
     this.HashKeyValue = predicates[hashKey].AttributeValueList[0]
-    this.RangeKeyValue = {
+    this.RangeKeyCondition = {
       ComparisonOperator: predicates[rangeKey].ComparisonOperator,
       AttributeValueList: predicates[rangeKey].AttributeValueList
     }


### PR DESCRIPTION
When generating queries from predicates, they are being put in attribute `RangeKeyValue` when they need to go in `RangeKeyCondition`. Right now, they are always being ignored.
