### PR TITLE
Allow a variable number of args to Scan/Query.get()

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -11,8 +11,8 @@ function Query(table, database) {
 }
 
 Query.prototype = {
-  get: function(attrs) {
-    this.AttributesToGet = attrs
+  get: function() {
+    this.AttributesToGet = Array.prototype.concat.apply([], arguments)
 
     return this
   },

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -17,8 +17,8 @@ Scan.prototype = {
     return this
   },
 
-  get: function(attrs) {
-    this.AttributesToGet = attrs
+  get: function() {
+    this.AttributesToGet = Array.prototype.concat.apply([], arguments)
 
     return this
   },


### PR DESCRIPTION
This allows you to do `table.scan().get('name').fetch(...)`, `table.scan().get('id', 'name').fetch(...)`, etc
