### PR TITLE
Support for range-less queries

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -29,18 +29,16 @@ Query.prototype = {
       , hashKey = keys[0]
       , rangeKey = keys[1]
 
-    if (keys.length != 2) {
-      throw new Error("Both hash and range keys are required for queries.")
-    }
-
     if (predicates[hashKey].ComparisonOperator != "EQ") {
       throw new Error("Query hash key comparison must be '=='.")
     }
 
     this.HashKeyValue = predicates[hashKey].AttributeValueList[0]
-    this.RangeKeyCondition = {
-      ComparisonOperator: predicates[rangeKey].ComparisonOperator,
-      AttributeValueList: predicates[rangeKey].AttributeValueList
+    if (rangeKey) {
+      this.RangeKeyCondition = {
+        ComparisonOperator: predicates[rangeKey].ComparisonOperator,
+        AttributeValueList: predicates[rangeKey].AttributeValueList
+      }
     }
 
     return this


### PR DESCRIPTION
Currently, the library doesn't allow queries that don't have a Range key, even though these are completely legal - say, to get all the values associated with a given key. I've removed that limitation.
