### PR TITLE
Connect to a non-amazon host

### DIFF
--- a/lib/Account.js
+++ b/lib/Account.js
@@ -15,9 +15,15 @@ function Account(credentials) {
   this.session = new Session(credentials)
 }
 
+Account.prototype.getForHost = function(host, port) {
+  var database = new Database(this);
+  database.host = host
+  database.port = port;
+  return database
+};
+
 Account.prototype.get = function(host) {
-  var database = new Database(this)
-    , badHost = !(host in regions)
+  var badHost = !(host in regions)
 
   if (badHost) {
     console.error(
@@ -25,12 +31,9 @@ Account.prototype.get = function(host) {
       "Please use client.get(region).get(table) instead, as this will soon be deprecated."
     )
 
-    database.host = "dynamodb.us-east-1.amazonaws.com"
-    return database.get(host)
+    return this.getForHost("us-east-1").get(host)
   }
-
-  database.host = "dynamodb." + host + ".amazonaws.com"
-  return database
+  return this.getForHost("dynamodb." + host + ".amazonaws.com");
 }
 
 Account.prototype.sign = function sign(request, cb) {

--- a/lib/Database.js
+++ b/lib/Database.js
@@ -58,7 +58,7 @@ Database.prototype = {
 
   request: function request(target, data, cb) {
     var self = this
-      , req = new Request(this.host, target, data)
+      , req = new Request(this.host, this.port, target, data);
 
     this.account.sign(req, function(err, req) {
       if (err) cb(err)

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -1,13 +1,15 @@
 var http   = require("http")
   , crypto = require("crypto")
 
-function Request(host, target, data) {
+function Request(host, port, target, data) {
   var headers = this.headers = new Headers
 
   this.json = JSON.stringify(data)
+  this.port = port
 
   headers["x-amz-target"] = Request.prototype.target + target
   headers["Host"] = this.host = host
+  if(port) this.headers["Host"] += ":" + port
   headers["Content-Length"] = Buffer.byteLength(this.json)
 }
 


### PR DESCRIPTION
I'm using [fake_dynamo](https://github.com/ananthakumaran/fake_dynamo) to test against a stub server locally, so I wanted to connect to something outside the list of known hosts.

It seems there's already a backwards-compatibility issue with create() that prevents overloading it with a specific host, so I added an alternative method createForHost() and tunneled the existing create() through it. I'm open to other suggestions though.
