### PR TITLE
Fixing utf-8 corruption issues for long strings

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -30,6 +30,8 @@ Request.prototype = {
     var request = http.request(this, function(res) {
       var json = ""
 
+      res.setEncoding('utf8')
+
       res.on("data", function(chunk){ json += chunk })
       res.on("end", function() {
         var error, response = JSON.parse(json)


### PR DESCRIPTION
Dynamo strings are utf8 by default, and when the string exceeds the chunk length, the last character can be partially cut off, unless the stream's encoding is properly set to utf8.
