### PR TITLE
Support array-based schema specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you'd like to run the test stuie with your own credentials, make sure they're
 
     npm test
 
-The test suite creates two tables called `DYNAMO_TEST_TABLE_1` and `DYNAMO_TEST_TABLE_2` before the tests are run, and then deletes them once the tests are done. Note that you will need to delete them manually in the event that the tests fail.
+The test suite creates three tables called `DYNAMO_TEST_TABLE_1`, `DYNAMO_TEST_TABLE_2`, and 'DYNAMO_TEST_TABLE_3` before the tests are run, and then deletes them once the tests are done. Note that you will need to delete them manually in the event that the tests fail.
 
 To do
 -----

--- a/lib/Key.js
+++ b/lib/Key.js
@@ -3,6 +3,25 @@ var Value = require("./Value")
 function Key(attrs) {
   if (!(this instanceof Key)) return new Key(attrs)
 
+  // See: http://stackoverflow.com/questions/4775722/javascript-check-if-object-is-array
+  //      http://blog.niftysnippets.org/2010/09/say-what.html
+  var typeStr = Object.prototype.toString.call(attrs)
+
+  function setSchema(value, pos) {
+    if (pos > 1) throw new Error("More than two key elements specified.")
+
+    this[["HashKeyElement", "RangeKeyElement"][pos]] = value
+  }
+
+  if (typeStr === "[object Object]") {
+    Object.keys(attrs).forEach(function(name, pos) {
+      setSchema.call(this, Value(attrs[name]), pos)
+    }, this)
+  } else if (typeStr === "[object Array]") {
+    attrs.forEach(function(element, pos) {
+      setSchema.call(this, Value(element[1]), pos)
+    }, this)
+  }
   Object.keys(attrs).forEach(function(name, pos) {
     if (pos > 1) throw new Error("More than two key elements specified.")
 

--- a/lib/Key.js
+++ b/lib/Key.js
@@ -3,30 +3,21 @@ var Value = require("./Value")
 function Key(attrs) {
   if (!(this instanceof Key)) return new Key(attrs)
 
-  // See: http://stackoverflow.com/questions/4775722/javascript-check-if-object-is-array
-  //      http://blog.niftysnippets.org/2010/09/say-what.html
-  var typeStr = Object.prototype.toString.call(attrs)
-
   function setSchema(value, pos) {
     if (pos > 1) throw new Error("More than two key elements specified.")
 
     this[["HashKeyElement", "RangeKeyElement"][pos]] = value
   }
 
-  if (typeStr === "[object Object]") {
-    Object.keys(attrs).forEach(function(name, pos) {
-      setSchema.call(this, Value(attrs[name]), pos)
-    }, this)
-  } else if (typeStr === "[object Array]") {
+  if (Array.isArray(attrs)) {
     attrs.forEach(function(element, pos) {
       setSchema.call(this, Value(element[1]), pos)
     }, this)
+  } else {
+    Object.keys(attrs).forEach(function(name, pos) {
+      setSchema.call(this, Value(attrs[name]), pos)
+    }, this)
   }
-  Object.keys(attrs).forEach(function(name, pos) {
-    if (pos > 1) throw new Error("More than two key elements specified.")
-
-    this[["HashKeyElement", "RangeKeyElement"][pos]] = Value(attrs[name])
-  }, this)
 }
 
 module.exports = Key

--- a/lib/KeySchema.js
+++ b/lib/KeySchema.js
@@ -8,17 +8,13 @@ function KeySchema(attrs) {
   }
 
   if (attrs) {
-    // See: http://stackoverflow.com/questions/4775722/javascript-check-if-object-is-array
-    //      http://blog.niftysnippets.org/2010/09/say-what.html
-    var typeStr = Object.prototype.toString.call(attrs)
-
-    if (typeStr === "[object Object]") {
-      Object.keys(attrs).forEach(function(name, pos) {
-        setSchemaKey.call(this, pos, name, attrs[name])
-      }, this)
-    } else if (typeStr === "[object Array]") {
+    if (Array.isArray(attrs)) {
       attrs.forEach(function(element, pos) {
         setSchemaKey.call(this, pos, element[0], element[1])
+      }, this)
+    } else {
+      Object.keys(attrs).forEach(function(name, pos) {
+        setSchemaKey.call(this, pos, name, attrs[name])
       }, this)
     }
   }

--- a/lib/KeySchema.js
+++ b/lib/KeySchema.js
@@ -2,11 +2,26 @@ var types = {S: String, N: Number}
   , keys = ["HashKeyElement", "RangeKeyElement"]
 
 function KeySchema(attrs) {
-  attrs && Object.keys(attrs).forEach(function(name, pos) {
+  function setSchemaKey(pos, keyName, keyType) {
     if (pos > 1) throw new Error("More than two keys specified.")
+    this[keys[pos]] = new SchemaKey(keyName, keyType)
+  }
 
-    this[keys[pos]] = new SchemaKey(name, attrs[name])
-  }, this)
+  if (attrs) {
+    // See: http://stackoverflow.com/questions/4775722/javascript-check-if-object-is-array
+    //      http://blog.niftysnippets.org/2010/09/say-what.html
+    var typeStr = Object.prototype.toString.call(attrs)
+
+    if (typeStr === "[object Object]") {
+      Object.keys(attrs).forEach(function(name, pos) {
+        setSchemaKey.call(this, pos, name, attrs[name])
+      }, this)
+    } else if (typeStr === "[object Array]") {
+      attrs.forEach(function(element, pos) {
+        setSchemaKey.call(this, pos, element[0], element[1])
+      }, this)
+    }
+  }
 }
 
 KeySchema.prototype = {

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,7 +7,9 @@ describe("setup -", function() {
   it("delete existing test tables", function(done) {
     db.remove("DYNAMO_TEST_TABLE_1", function() {
       db.remove("DYNAMO_TEST_TABLE_2", function() {
-        done()
+        db.remove("DYNAMO_TEST_TABLE_3", function() {
+          done()
+        })
       })
     })
   })
@@ -15,7 +17,9 @@ describe("setup -", function() {
   it("make sure no test tables exist", function(done) {
     db.get("DYNAMO_TEST_TABLE_1").watch(function() {
       db.get("DYNAMO_TEST_TABLE_2").watch(function() {
-        done()
+        db.get("DYNAMO_TEST_TABLE_3").watch(function() {
+          done()
+        })
       })
     })
   })
@@ -64,6 +68,29 @@ describe("setup -", function() {
         table.should.have.property("ProvisionedThroughput")
         table.ProvisionedThroughput.should.have.property("ReadCapacityUnits", 4)
         table.ProvisionedThroughput.should.have.property("WriteCapacityUnits", 6)
+
+        done()
+      })
+  })
+
+  it("create test table with schema array", function(done) {
+    db.add({
+        name: "DYNAMO_TEST_TABLE_3",
+        schema: [ ['id', String], ['date', Number] ]
+      })
+      .save(function(err, table) {
+        should.not.exist(err)
+        should.exist(table)
+
+        table.should.have.property("TableName", "DYNAMO_TEST_TABLE_3")
+
+        table.should.have.property("KeySchema")
+        table.KeySchema.should.have.property("HashKeyElement")
+        table.KeySchema.HashKeyElement.should.have.property("AttributeName", "id")
+        table.KeySchema.HashKeyElement.should.have.property("AttributeType", String)
+        table.KeySchema.should.have.property("RangeKeyElement")
+        table.KeySchema.RangeKeyElement.should.have.property("AttributeName", "date")
+        table.KeySchema.RangeKeyElement.should.have.property("AttributeType", Number)
 
         done()
       })

--- a/test/teardown.js
+++ b/test/teardown.js
@@ -7,7 +7,9 @@ describe("teardown -", function() {
   it("delete existing test tables", function(done) {
     db.remove("DYNAMO_TEST_TABLE_1", function() {
       db.remove("DYNAMO_TEST_TABLE_2", function() {
-        done()
+        db.remove("DYNAMO_TEST_TABLE_3", function() {
+          done()
+        })
       })
     })
   })
@@ -15,7 +17,9 @@ describe("teardown -", function() {
   it("make sure no test tables exist", function(done) {
     db.get("DYNAMO_TEST_TABLE_1").watch(function() {
       db.get("DYNAMO_TEST_TABLE_2").watch(function() {
-        done()
+        db.get("DYNAMO_TEST_TABLE_3").watch(function() {
+          done()
+        })
       })
     })
   })


### PR DESCRIPTION
(See https://github.com/jed/dynamo/issues/9).

Instead of relying on order-of-insertion traversal of object properties, an
unspecified behavior of javascript, users may specify hash and range keys in an
array of arrays, where the sub-arrays contain the attribute name and attribute
type as the first and second elements, respectively.

So, instead of calling

```
db.add({
    name: "myTable",
    schema: {id: String, date: Number},
  }).save(function(err, table){ ... })
```

you would call:

```
db.add({
    name: "myTable",
    schema: [ ['id', String], ['date', Number] ],
  }).save(function(err, table){ ... })
```
