### PR TITLE
Bug fix on UpdateItem API

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -50,6 +50,15 @@ Query.prototype = {
     return this
   },
 
+  limit: function(limit) {
+    if(isNaN(limit) || ((limit|0) != limit)) {
+      throw new Error("Limit should be an integer");
+    }
+
+    this.Limit = limit;
+    return this;
+  },
+
   fetch: function(opts, cb) {
     var self = this
       , response = []
@@ -70,9 +79,16 @@ Query.prototype = {
             response.push(Attributes.prototype.parse(item))
           })
 
-          if (data.LastEvaluatedKey) loop(data.LastEvaluatedKey)
-
-          else cb(null, response)
+          if (data.LastEvaluatedKey) {
+            if (self.Limit != null && self.Limit < response.length) {
+              loop(data.LastEvaluatedKey)
+              return
+            } else {
+              cb(null, response)
+            }
+          } else {
+            cb(null, response)
+          }
         }
       )
     }(this.ExclusiveStartKey)

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -51,8 +51,8 @@ Query.prototype = {
   },
 
   limit: function(limit) {
-    if(isNaN(limit) || ((limit|0) != limit)) {
-      throw new Error("Limit should be an integer");
+    if(isNaN(limit) || ((limit|0) != limit) || (limit|0) < 1) {
+      throw new Error("Limit should be an natural number");
     }
 
     this.Limit = limit;
@@ -82,7 +82,6 @@ Query.prototype = {
           if (data.LastEvaluatedKey) {
             if (self.Limit != null && self.Limit < response.length) {
               loop(data.LastEvaluatedKey)
-              return
             } else {
               cb(null, response)
             }

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -29,6 +29,15 @@ Scan.prototype = {
     return this
   },
 
+  limit: function(limit) {
+    if(isNaN(limit) || ((limit|0) != limit) || (limit|0) < 1) {
+      throw new Error("Limit should be an natural number");
+    }
+
+    this.Limit = limit;
+    return this;
+  },
+
   fetch: function(cb) {
     var self = this
       , response = []
@@ -46,9 +55,15 @@ Scan.prototype = {
             response.push(Attributes.prototype.parse(item))
           })
 
-          if (data.LastEvaluatedKey) loop(data.LastEvaluatedKey)
-
-          else cb(null, response)
+          if (data.LastEvaluatedKey) {
+            if (self.Limit != null && self.Limit < response.length) {
+              loop(data.LastEvaluatedKey)
+            } else {
+              cb(null, response)
+            }
+          } else {
+            cb(null, response)
+          }
         }
       )
     }(this.ExclusiveStartKey)

--- a/lib/Update.js
+++ b/lib/Update.js
@@ -70,8 +70,8 @@ Update.prototype = {
     return this.update("ADD", key, value)
   },
 
-  remove: function(key) {
-    return this.update("DELETE", key)
+  remove: function(key, value) {
+    return this.update("DELETE", key, value)
   },
 
   save: function(cb) {


### PR DESCRIPTION
In DynamoDB APIS, UpdateItem api can take values in delete
operation. For example, delete [1,2] from NS [1,2,3]
will result [3]. So, I changed Update.js that remove
operaiton can take values as argument.

http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_UpdateItem.html
